### PR TITLE
token sale improvements

### DIFF
--- a/src/KeyTokenSale.sol
+++ b/src/KeyTokenSale.sol
@@ -112,7 +112,7 @@ contract KeyTokenSale is DSStop, DSMath, DSExec {
 
         uint toReturn = sub(msg.value, toFund);
         if(toReturn > 0) {
-            msg.sender.transfer(toReturn);
+            exec(msg.sender, toReturn);
         }
     }
 
@@ -123,7 +123,7 @@ contract KeyTokenSale is DSStop, DSMath, DSExec {
         endTime = startTime + 14 days;
     }
 
-    function finalize() auth note{
+    function finalize() auth note {
         require(time() >= endTime);
 
         uint256 unsold = sub(SELL_HARD_LIMIT, sold);
@@ -140,20 +140,14 @@ contract KeyTokenSale is DSStop, DSMath, DSExec {
     }
 
 
-    /// @notice This method can be used by the controller to extract mistakenly
-    ///  sent tokens to this contract.
-    /// @param _token The address of the token contract that you want to recover
-    ///  set to 0 in case you want to extract ether.
-    function claimTokens(address _token) public auth note{
-
-        if (_token == 0x0) {
-            owner.transfer(this.balance);
-            return;
-        }
-
+    // @notice This method can be used by the controller to extract mistakenly
+    //  sent tokens to this contract.
+    // @param dst The address that will be receiving the tokens
+    // @param wad The amount of tokens to transfer
+    // @param _token The address of the token contract that you want to recover
+    function transferTokens(address dst, uint wad, address _token) public auth note {
         ERC20 token = ERC20(_token);
-        uint256 balance = token.balanceOf(this);
-        token.transfer(owner, balance);
+        token.transfer(dst, wad);
     }
 
 }

--- a/src/KeyTokenSale.t.sol
+++ b/src/KeyTokenSale.t.sol
@@ -64,6 +64,10 @@ contract TestableKeyTokenSale is KeyTokenSale {
     function addTime(uint extra) {
         localTime += extra;
     }
+
+    function canBuy(uint total) returns (bool) {
+        return msg.sender == owner ? true : total < USER_BUY_LIMIT;
+    }
 }
 
 contract KeyTokenSaleTest is DSTest, DSExec {

--- a/src/KeyTokenSale.t.sol
+++ b/src/KeyTokenSale.t.sol
@@ -43,8 +43,6 @@ contract KeyTokenOwner {
         key.stop();
     }
 
-
-
     function() payable {}
 }
 
@@ -118,7 +116,11 @@ contract KeyTokenSaleTest is DSTest, DSExec {
     }
 
     function testClaimTokens() {
-        //sale.claimTokens(address(0x0));
+        DSToken test = new DSToken("TST");
+        test.mint(1 ether);
+        test.push(sale, 1 ether);
+        assertEq(test.balanceOf(this), 0);
+        sale.transferTokens(this, 1 ether, test);
     }
 
 


### PR DESCRIPTION
claimTokens has been changed to transferTokens, allowing you to specify a destination and amount to transfer from the contract. Ether extraction has been removed because the only `payable` function is the fallback function and it transfers all the Ether it receives or reverts the transaction.

I also removed some redundant code and cleaned up the logic.